### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+.idea/**/gradle.xml
+.idea/**/libraries
+
+ # Gradle and Maven with auto-import
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+out/
+gradle
+build
+.gradle


### PR DESCRIPTION
- Gradle build files are big and shouldn't be in the git track. 

- .idea folder contains user-specific and sensitive data. Ignore it.

- out folder contains compiled files. .class files should be ignored.